### PR TITLE
#17 Implement total rank

### DIFF
--- a/API_Game_server/Controllers/DTO/Rank.cs
+++ b/API_Game_server/Controllers/DTO/Rank.cs
@@ -7,4 +7,8 @@ namespace API_Game_Server.Controllers.DTO
         public string UserName {  get; set; }
         public double Score { get; set; }
     }
+    public class RanksReq
+    { 
+        public int Page {  get; set; } 
+    }
 }

--- a/API_Game_server/Controllers/RankController.cs
+++ b/API_Game_server/Controllers/RankController.cs
@@ -17,7 +17,7 @@ namespace API_Game_Server.Controllers
         }
         // 유저 닉네임을 인자로 넘기면, 등수를 알 수 있다.
         [HttpGet("{UserName}")]
-        public async Task<ActionResult> Get(string UserName)
+        public async Task<ActionResult> GetRank(string UserName)
         {
             var result = await _db.GetZsetRank("rank", UserName);
             if (result == null)
@@ -29,11 +29,42 @@ namespace API_Game_Server.Controllers
         // 유저의 점수를 업로드하면, Redis의 Sorted Set에 정렬된다.
         // 이후 해당 유저의 등수를 반환한다.
         [HttpPost]
-        public async Task<ActionResult> Post(RankReq req)
+        public async Task<ActionResult> UpdateRank(RankReq req)
         {
             await _db.SetZset("rank", req.UserName, req.Score);
-            var result = await Get(req.UserName);
+            var result = await GetRank(req.UserName);
             return result;
+        }
+        // 조회하고자 하는 page를 인자로 넘기면
+        // page에 해당하는 랭커들을 조회하여 string[] 데이터로 반환한다.
+        [HttpPost("/total-rank")]
+        public async Task<ActionResult> LoadRanks(RanksReq req)
+        {
+            RedisValue[] result = await _db.GetZsetRanks("rank", req.Page);
+            if (result.Length == 0)
+            {
+                return BadRequest();
+            }
+            return Ok(Array.ConvertAll(result, x => (string)x));
+        }
+
+        // 전체 랭크의 개수를 반환한다.
+        // 클라이언트가 전체 랭킹을 조회할 때, 마지막 페이지를 명시할 때 사용된다.
+        [HttpGet("/size-rank")]
+        public async Task<ActionResult> SizeRank()
+        {
+            long result = await _db.GetZsetSize("rank");
+            if (result == 0)
+                return BadRequest();
+            return Ok(result);
+        }
+
+        // rank를 key로 하는 zset의 모든 데이터 삭제
+        [HttpDelete]
+        public async Task<ActionResult> ClearRank()
+        {
+            long result = await _db.ClearZset("rank");
+            return Ok(result);
         }
     }
 }

--- a/API_Game_server/Program.cs
+++ b/API_Game_server/Program.cs
@@ -10,7 +10,7 @@ var builder = WebApplication.CreateBuilder(args);
 
 IConfiguration configuration = builder.Configuration;
 
-// DB ���� ������ ���Ӽ� �������� �־��ֱ� ����
+// DB 연결 설정을 종속성 주입으로 넣어주기 위함
 builder.Services.Configure<DBConfig>(configuration.GetSection(nameof(DBConfig)));
 
 // Add services to the container.
@@ -34,7 +34,7 @@ app.UseAuthorization();
 
 app.MapControllers();
 
-// DB �ʱ�ȭ (DB�� ������ �� ����ϴ� mysql connection string�� ����)
+// DB 초기화 (DB에 연결할 때 사용하는 mysql connection string을 설정)
 Database.Init(app.Configuration);
 
 app.Run();

--- a/API_Game_server/Repository/RedisDB.cs
+++ b/API_Game_server/Repository/RedisDB.cs
@@ -22,13 +22,16 @@ namespace API_Game_Server.Repository
         public async Task<bool> SetString(string key, string value)
         {
             // Set 성공시 true
-            return await _db.StringSetAsync(key, value);
+            bool result = await _db.StringSetAsync(key, value);
+            return result;
         }
         public async Task<RedisValue> GetString(string key)
         {
-            // Get 실패시 nil 반환
-            return await _db.StringGetAsync(key);
+            // Get 실패시 nil
+            RedisValue result = await _db.StringGetAsync(key);
+            return result;
         }
+
         // Hash 자료형
         // HashEntry는 name, value가 한 쌍인 객체
         public async Task SetHash(string key, HashEntry[] entries)
@@ -37,21 +40,42 @@ namespace API_Game_Server.Repository
         }
         public async Task<RedisValue[]> GetHash(string key, RedisValue[] hashFields)
         {
-            return await _db.HashGetAsync(key, hashFields);
+            RedisValue[] result = await _db.HashGetAsync(key, hashFields);
+            return result;
         }
+
         // Sorted Sets 자료형
         public async Task<bool> SetZset(string key,  string member, double score)
         {
             // true : 기존에 없던 member
             // false : 기존에 존재한 member - 하지만 업데이트는 된다
-            var result = await _db.SortedSetAddAsync((RedisKey)key, (RedisValue)member, score);
+            bool result = await _db.SortedSetAddAsync((RedisKey)key, (RedisValue)member, score);
             return result;
         }
         public async Task<long?> GetZsetRank(string key, string member)
         {
             // 해당 멤버가 없으면 null 반환
             // 있으면 랭크 반환 ( 1등은 0 반환 )
-            var result = await _db.SortedSetRankAsync((RedisKey)key, (RedisValue)member, Order.Descending);
+            long? result = await _db.SortedSetRankAsync((RedisKey)key, (RedisValue)member, Order.Descending);
+            return result;
+        }
+        public async Task<RedisValue[]> GetZsetRanks(string key, int page)
+        {
+            long startNum = (page - 1) * 15;
+            long endNum = (page) * 15 - 1;
+            RedisValue[] result = await _db.SortedSetRangeByRankAsync(key, startNum, endNum, Order.Descending);
+            return result;
+        }
+        public async Task<long> GetZsetSize(string key)
+        {
+            // 존재하지 않을 경우 0 반환
+            long result = await _db.SortedSetLengthAsync(key);
+            return result;
+        }
+
+        public async Task<long> ClearZset(string key)
+        {
+            long result = await _db.SortedSetRemoveRangeByRankAsync(key, 0, -1);
             return result;
         }
     }


### PR DESCRIPTION
```/total-rank``` path로 랭킹을 조회한다.   
조회할 때 메서드는 ```POST```로, 조회하고자 하는 ```Page```를 인자로 넘긴다.   
```Page```는 유저가 조회하는 전체 랭킹의 페이지 수 이며, 한 페이지에 15명을 볼 수 있다.   

```/size-rank``` path로 전체 랭킹에 등록되어 있는 유저의 수를 조회한다.   
조회할 때 메서드는 ```GET```으로, 클라이언트에서 마지막 페이지를 명시하기 위해 작성한 API이다.   

테스트를 위해 랭킹 유저의 모든 데이터를 삭제하는 ```ClearRank```함수를 작성했다.   

closes #17 
