### PR TITLE
친구 목록 조회 기능 구현 완료

### DIFF
--- a/API_Game_server/Controllers/Friend/FriendListController.cs
+++ b/API_Game_server/Controllers/Friend/FriendListController.cs
@@ -1,0 +1,27 @@
+using API_Game_Server.Model.DTO;
+using API_Game_Server.Model.DAO;
+using API_Game_Server.Repository;
+using API_Game_Server.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace API_Game_Server.Controllers
+{
+    [Route("[controller]")]
+    [ApiController]
+    public class FriendListController : ControllerBase
+    {
+        private readonly FriendListService friendListService;
+        public FriendListController(FriendListService _friendListService)
+        {
+            friendListService = _friendListService;
+        }
+        [HttpPost]
+        public async Task<FriendListRes> GetFriendList(FriendListReq req)
+        {
+            FriendListRes res = new FriendListRes();
+            (res.Result, res.FriendList) = await friendListService.FriendList(req.MyToken);
+            return res;
+        }
+    }
+}

--- a/API_Game_server/ErrorCode.cs
+++ b/API_Game_server/ErrorCode.cs
@@ -3,7 +3,6 @@ public enum EErrorCode
     None = 0,
     InvalidToken = 1,
     DontKnow = 2,
-    ReverseMake = 3,
 
     // Account 1000~1999    
     Create_Account_Fail = 1001,

--- a/API_Game_server/Model/DAO/Friend/FriendList_DAO.cs
+++ b/API_Game_server/Model/DAO/Friend/FriendList_DAO.cs
@@ -1,0 +1,9 @@
+using System.ComponentModel;
+
+namespace API_Game_Server.Model.DAO
+{
+    public class FriendElement
+    {
+        public string UserName { get; set; }
+    }
+}

--- a/API_Game_server/Model/DTO/Friend/FriendList_DTO.cs
+++ b/API_Game_server/Model/DTO/Friend/FriendList_DTO.cs
@@ -1,0 +1,16 @@
+using System.ComponentModel;
+using API_Game_Server.Model.DAO;
+
+namespace API_Game_Server.Model.DTO
+{
+    //  요청 데이터
+    public class FriendListReq
+    {
+        public string MyToken { get; set; }
+    }
+    // 응답 데이터
+    public class FriendListRes : ErrorCodeDTO
+    {
+        public IEnumerable<FriendElement> FriendList { get; set; } // DAO의 친구 요소로 이루어진 List를 반환
+    }
+}

--- a/API_Game_server/Program.cs
+++ b/API_Game_server/Program.cs
@@ -21,6 +21,7 @@ builder.Services.AddTransient<FriendRequestService>();
 builder.Services.AddTransient<FriendRequestAcceptService>();
 builder.Services.AddTransient<FriendRequestListService>();
 builder.Services.AddTransient<FriendRequestDenyService>();
+builder.Services.AddTransient<FriendListService>();
 builder.Services.AddTransient<GameResultService>();
 builder.Services.AddTransient<AuthService>();
 builder.Services.AddTransient<AttendanceService>();

--- a/API_Game_server/Services/Friend/FriendListServcie.cs
+++ b/API_Game_server/Services/Friend/FriendListServcie.cs
@@ -1,0 +1,45 @@
+using API_Game_Server.Repository;
+using API_Game_Server.Model.DTO;
+using API_Game_Server.Model.DAO;
+using System;
+
+namespace API_Game_Server.Services
+{
+    public class FriendListService
+    {
+        private readonly GameDB gameDB;
+        private readonly RedisDB redisDB;
+        private readonly ValidationService validationService;
+        public FriendListService(GameDB _gameDB, RedisDB _redisDB, ValidationService _validationService)
+        {
+            gameDB = _gameDB;
+            redisDB = _redisDB;
+            validationService = _validationService;
+        }
+        public async Task<(EErrorCode, IEnumerable<FriendElement>)> FriendList(string token)
+        {
+            // 토큰 유효성 검사
+            string myUid = await validationService.GetUid(token);
+            // 유효하지 않은 토큰이면
+            if(myUid == "")
+            {
+                return (EErrorCode.InvalidToken, null);
+            }
+
+            // 가져온 uid 이용해서 클라이언트의 user_name 조회
+            string uidKey = string.Format("user_info:uid:{0}", myUid);
+            string[] arrUidValues = {"user_name"};
+            string[] arrMyName = await redisDB.GetHash(uidKey, arrUidValues); // 받아올 칼럼명을 프로퍼티명으로 전달
+            string myName = arrMyName[0];
+
+            // FRIEND_RELATIONSHIP 테이블에서 친구 목록 가져오기
+            string nameKey = string.Format("friend_relationship:{0}",myName);
+            string[] friendUserNames = await redisDB.GetSetMembers(nameKey);
+            IEnumerable<FriendElement> friendList = friendUserNames.Select(userName => new FriendElement
+            {
+                UserName = userName
+            });
+            return (EErrorCode.None, friendList);
+        }
+    }
+}

--- a/API_Game_server/Services/Friend/FriendRequestService.cs
+++ b/API_Game_server/Services/Friend/FriendRequestService.cs
@@ -81,7 +81,7 @@ namespace API_Game_Server.Services
                 await redisDB.AddSetElement(addElementKey1, toUserName); // redis 저장
                 await redisDB.AddSetElement(addElementKey2, myName); // redis 저장
                 await gameDB.DeleteFriendRequest(toUserName,myName); // 역방향 신청 삭제
-                return EErrorCode.ReverseMake;
+                return EErrorCode.None;
             }
 
             // 신청이 완료된 경우


### PR DESCRIPTION
클라이언트가 친구 목록 조회 요청 시 클라이언트의 요청에 토큰을 전달받아서 해당 유저의 이름을 이용해서 redis의 FRIEND_RELATIONSHIP 테이블에서 key값이 유저의 이름인 value를 가져온다
가져온 value는 string[] 이기 때문에 DTO에 맞추기 위해 DAO인 FriendElement 객체에 string 값을 하나씩 담아서 IEnumerable로 만들어서 클라이언트에게 응답한다