### PR TITLE
변수명 변경

### DIFF
--- a/API_Game_server/Controllers/LoginController.cs
+++ b/API_Game_server/Controllers/LoginController.cs
@@ -43,7 +43,7 @@ public class LoginController : ControllerBase
         }
 
         // 세션ID 발급, redis에 추가
-        (errorCode, response.SessionId) = await authService.GenerateSessionId(request.UserId);
+        (errorCode, response.SessionId) = await authService.GenerateSessionId(response.Uid);
         if(errorCode == EErrorCode.LoginFailAddRedis)
         {
             response.Result = errorCode;


### PR DESCRIPTION
Redis에는 GameDB의 uid가 들어가 있어야 되는데 AccountDB에서 넘어온
userID를 넘겨주고 있어서 uid를 넘겨주도록 변경함