### PR TITLE
GameResult에 Redis 적용, 사용하지 않는 ErrorCode 정리, MailDTO 필요에 따라 구분

### DIFF
--- a/API_Game_server/Controllers/Mail/MailListController.cs
+++ b/API_Game_server/Controllers/Mail/MailListController.cs
@@ -20,10 +20,10 @@ namespace API_Game_Server.Controllers
         }
 
         [HttpPost]
-        public async Task<MailRes> PostAsync(MailReq req)
+        public async Task<MailListRes> PostAsync(MailListReq req)
         {
             //응답 객체 생성
-            MailRes res = new();
+            MailListRes res = new();
 
             // 메일 리스트 불러오기
             res.Result = await mailService.GetMailListAsync(req, res);

--- a/API_Game_server/Controllers/Mail/MailOpenController.cs
+++ b/API_Game_server/Controllers/Mail/MailOpenController.cs
@@ -19,10 +19,10 @@ namespace API_Game_Server.Controllers
         }
 
         [HttpPost]
-        public async Task<MailRes> PostAsync(MailReq req)
+        public async Task<MailOpenRes> PostAsync(MailOpenReq req)
         {
             //응답 객체 생성
-            MailRes res = new();
+            MailOpenRes res = new();
             res.Result = await mailService.OpenMailAsync(req);
             return res;
         }

--- a/API_Game_server/ErrorCode.cs
+++ b/API_Game_server/ErrorCode.cs
@@ -32,15 +32,13 @@ public enum EErrorCode
     GameResultService_RewardCalcFail                = 3002,
     GameResultService_AddLevelUpRewardFail          = 3003,
     GameResultService_UserInfoUpdateError           = 3004,
+    GameResultService_RedisUpdateError              = 3005,
 
     // GameDB_Mail 3100~3199
-    MailService_AddFail                              = 3101,
-    MailService_RemoveFail                           = 3102,
-    MailService_UpdateFail                           = 3103,
-    MailService_GetFail                              = 3104,
-    MailService_GetListFail                          = 3105,
-    MailService_GetInfoFail                          = 3106,
-    MailService_RewardFail                           = 3107,
+    MailService_OpenFail                            = 3100,
+    MailService_GetListFail                         = 3101,
+    MailService_GetInfoFail                         = 3102,
+    MailService_RewardFail                          = 3103,
 
     // GameDB_GameResult 3200~3299
     //GameDB_GetUserInfoFail = 3201,

--- a/API_Game_server/Model/DTO/Mail/Mail_DTO.cs
+++ b/API_Game_server/Model/DTO/Mail/Mail_DTO.cs
@@ -4,15 +4,24 @@ using System.ComponentModel;
 namespace API_Game_Server.Model.DTO
 {
     // 요청 데이터
-    public class MailReq
+    public class MailListReq
+    {
+        public string Token { get; set; }
+    }
+
+    public class MailOpenReq
     {
         public string Token { get; set; }
         public int MailboxId { get; set; }
     }
 
     // 응답 데이터
-    public class MailRes : ErrorCodeDTO
+    public class MailListRes : ErrorCodeDTO
     {
         public IEnumerable<MailInfo> MailList { get; set; }
+    }
+
+    public class MailOpenRes : ErrorCodeDTO
+    {
     }
 }

--- a/API_Game_server/Repository/GameDB_Result.cs
+++ b/API_Game_server/Repository/GameDB_Result.cs
@@ -10,15 +10,6 @@ namespace API_Game_Server.Repository;
 
 public partial class GameDB : IDisposable
 {
-    //TODO.김초원 : 쓰는 사람 없으면 제거하기
-    public Task<ResultUserInfo> GetUserInfo(long id)
-    {
-        return queryFactory.Query("USER_INFO")
-        .Select("uid", "level", "exp", "money", "diamond", "max_score as MaxScore", "user_name as UserName")
-        .Where("uid", id)
-        .FirstOrDefaultAsync<ResultUserInfo>();
-    }
-
     public Task<ResultUserInfo> GetUserInfoAsync(long id)
     {
         return queryFactory.Query("USER_INFO")

--- a/API_Game_server/Services/AttendanceService.cs
+++ b/API_Game_server/Services/AttendanceService.cs
@@ -159,7 +159,7 @@ namespace API_Game_Server.Services
         {
             int rewardCode = rewardItem.Code;
             int rewardCount = rewardItem.Count;
-            ResultUserInfo user = await gameDB.GetUserInfo(info.Uid);
+            ResultUserInfo user = await gameDB.GetUserInfoAsync(info.Uid);
             if (user == null) return EErrorCode.NotExistUserDoingReward;
             switch (rewardCode)
             {

--- a/API_Game_server/Services/AuthService.cs
+++ b/API_Game_server/Services/AuthService.cs
@@ -58,7 +58,7 @@ public class AuthService
         // 발급한 세션ID redis에 추가
 
         // 1. gameDB에서 user_info 조회
-        ResultUserInfo userInfo = await gameDb.GetUserInfo(uid);
+        ResultUserInfo userInfo = await gameDb.GetUserInfoAsync(uid);
         if (userInfo == null) return (EErrorCode.LoginFailAddRedis, null);
         // 2. redis에 저장하기 위한 인스턴스 생성
         RedisUserInfo redis_info = GenerateSessionInfo(sessionId, userInfo);

--- a/API_Game_server/Services/GameResult/GameResultService.cs
+++ b/API_Game_server/Services/GameResult/GameResultService.cs
@@ -3,6 +3,7 @@ using API_Game_Server.Model.DAO;
 using API_Game_Server.Repository;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.VisualBasic.FileIO;
+using System;
 
 namespace API_Game_Server.Services
 {
@@ -23,7 +24,7 @@ namespace API_Game_Server.Services
 
         // 
         private readonly int maxMoney = 99999;
-        private ResultUserInfo userinfo;
+        private ResultUserInfo userInfo;
         private int totalScore = 0;
         private int totalMoney = 0;
 
@@ -40,15 +41,38 @@ namespace API_Game_Server.Services
         {
             // UID 얻기
             long uid = -1;
+            string stringUid;
             try
             {
-                string stringUid = await validationService.GetUid(req.Token);
+                stringUid = await validationService.GetUid(req.Token);
                 uid = long.Parse(stringUid);
-                userinfo = await gameDB.GetUserInfoAsync(uid);
             }
             catch
             {
                 return EErrorCode.InvalidToken;
+            }
+
+            try
+            {
+                // Redis에서 정보 찾기
+                string uidKey = string.Format("user_info:uid:{0}", stringUid);
+                string[] arrValues = { "user_name", "level", "exp", "money", "max_score", "diamond" };
+                string[] value = await redisDB.GetHash(uidKey, arrValues);
+
+                userInfo = new ResultUserInfo
+                {
+                    Uid = uid,
+                    UserName = value[0],
+                    Level = int.Parse(value[1]),
+                    Exp = int.Parse(value[2]),
+                    Money = int.Parse(value[3]),
+                    MaxScore = int.Parse(value[4]),
+                    Diamond = int.Parse(value[5])
+                };
+            }
+            catch
+            {
+                userInfo = await gameDB.GetUserInfoAsync(uid);
             }
 
             // 플레이 검증
@@ -77,7 +101,7 @@ namespace API_Game_Server.Services
 
             try
             {
-                await UpdateUserInfoAsync(userinfo.Uid, newLevel, newExp, newMoney, userinfo.Diamond, newMaxScore, userinfo.UserName);
+                await UpdateUserInfoAsync(userInfo.Uid, newLevel, newExp, newMoney, userInfo.Diamond, newMaxScore, userInfo.UserName);
             }
             catch
             {
@@ -87,7 +111,7 @@ namespace API_Game_Server.Services
 
             try
             {
-                bool bLevelUp = newLevel != userinfo.Level;
+                bool bLevelUp = newLevel != userInfo.Level;
                 if (bLevelUp)
                     AddReward(newLevel);
             }
@@ -98,8 +122,27 @@ namespace API_Game_Server.Services
                 return EErrorCode.GameResultService_AddLevelUpRewardFail;
             }
 
+            RedisUserInfo redisUserInfo = new RedisUserInfo
+            {
+                SessionId = req.Token,
+                UserName = userInfo.UserName,
+                Level = newLevel,
+                Exp = newExp,
+                Money = newMoney,
+                MaxScore = newMaxScore,
+                Diamond = userInfo.Diamond
+            };
+
             // Redis 저장
-            await redisDB.SetZset("rank", userinfo.UserName, newMaxScore);
+            try
+            {
+                await redisDB.SetZset("rank", userInfo.UserName, newMaxScore);
+                await redisDB.SetHash($"user_info:uid:{userInfo.Uid}", redisUserInfo);
+            }
+            catch
+            {
+                return EErrorCode.GameResultService_RedisUpdateError;
+            }
 
             res.Exp = newExp;
             res.Level = newLevel;
@@ -110,10 +153,9 @@ namespace API_Game_Server.Services
 
         public int CalcMaxScore()
         {
-            int newMaxScore = userinfo.MaxScore;
+            int newMaxScore = userInfo.MaxScore;
             if (newMaxScore < totalScore)
             {
-                // Redis 랭킹 업데이트
                 newMaxScore = totalScore;
             }
 
@@ -123,27 +165,27 @@ namespace API_Game_Server.Services
         public void AddReward(int newLevel)
         {
             int rewardCount = 0;
-            for (int i = userinfo.Level + 1; i <= newLevel; i++)
+            for (int i = userInfo.Level + 1; i <= newLevel; i++)
             {
                 rewardCount += i * 10;
                 DateTime sevenDaysLater = DateTime.Now.AddDays(7);
-                _ = mailService.AddMailAsync(userinfo.Uid, "운영자", "레벨업 보상", rewardCount, false, "diamond", sevenDaysLater);
+                _ = mailService.AddMailAsync(userInfo.Uid, "운영자", "레벨" + i + "달성을 축하합니다.", rewardCount, false, "diamond", sevenDaysLater);
             }
         }
 
         public int CalcMoney()
         {
-            return userinfo.Money + totalMoney < maxMoney ? userinfo.Money + totalMoney : maxMoney;
+            return userInfo.Money + totalMoney < maxMoney ? userInfo.Money + totalMoney : maxMoney;
         }
 
         public int CalcExp()
         {
-            return userinfo.Exp + totalScore;
+            return userInfo.Exp + totalScore;
         }
 
         public int CalcLevel(int newExp)
         {
-            int newLevel = userinfo.Level;
+            int newLevel = userInfo.Level;
             for (int level = newLevel; level <= userLevelData.Count; level++)
             {
                 if (newExp < userLevelData[level].MinExp)
@@ -158,9 +200,9 @@ namespace API_Game_Server.Services
 
         public Task UpdateUserInfoAsync(long uid, int newLevel, int newExp, int newMoney, int newDiamond, int newMaxScore, string userName)
         {
-            if (newMoney != userinfo.Money || newExp != userinfo.Exp || newLevel != userinfo.Level || newMaxScore != userinfo.MaxScore)
+            if (newMoney != userInfo.Money || newExp != userInfo.Exp || newLevel != userInfo.Level || newMaxScore != userInfo.MaxScore)
             {
-                return gameDB.UpdateUserInfoAsync(uid, newLevel, newExp, newMoney, userinfo.Diamond, newMaxScore, userinfo.UserName);
+                return gameDB.UpdateUserInfoAsync(uid, newLevel, newExp, newMoney, userInfo.Diamond, newMaxScore, userInfo.UserName);
             }
 
             return Task.CompletedTask;

--- a/API_Game_server/Services/Mail/MailService.cs
+++ b/API_Game_server/Services/Mail/MailService.cs
@@ -22,7 +22,7 @@ namespace API_Game_Server.Services
             this.validationService = validationService;
         }
 
-        public async Task<EErrorCode> GetMailListAsync(MailReq req, MailRes res)
+        public async Task<EErrorCode> GetMailListAsync(MailListReq req, MailListRes res)
         {
             // UID 얻기
             long uid = -1;
@@ -53,7 +53,7 @@ namespace API_Game_Server.Services
             return gameDB.AddMailAsync(id, sender, content, count, isRead, rewardType, expiredAt);
         }
 
-        public async Task<EErrorCode> OpenMailAsync(MailReq req)
+        public async Task<EErrorCode> OpenMailAsync(MailOpenReq req)
         {
             // UID 얻기
             long uid = -1;
@@ -75,7 +75,7 @@ namespace API_Game_Server.Services
             try
             {
                 mailInfo = await gameDB.GetMailAsync(uid, req.MailboxId);
-                userInfo = await gameDB.GetUserInfo(uid);
+                userInfo = await gameDB.GetUserInfoAsync(uid);
             }
             catch
             {


### PR DESCRIPTION
[작업 내용]
- GameResult에 Redis 적용
  - 클라이언트 정보를 Redis 확인 -> Redis에 없는 경우 DB 확인으로 로직 변경
- 사용하지 않는 ErrorCode 정리
- Mail 관련 DTO를 하나로 쓰다보니 필요없는 정보를 res에 담는 경우가 생김
  - MailList와 MailOpen으로 나누어 관리
- GameDB Repository에 있는 GetUserInfo 함수명을 GetUserInfoAsync로 변경
  - 관련 함수를 호출하는 곳 수정

closes #63 