### PR TITLE
rank api 점수와 닉네임 같이 반환하도록 수정

### DIFF
--- a/API_Game_server/Model/DTO/Rank_DTO.cs
+++ b/API_Game_server/Model/DTO/Rank_DTO.cs
@@ -18,7 +18,7 @@ namespace API_Game_Server.Model.DTO
     }
     public class  RankGetRes : ErrorCodeDTO
     {
-        public long Rank { get; set; }
+        public string Rank { get; set; }
     }
     public class RankSizeRes : ErrorCodeDTO
     {

--- a/API_Game_server/Model/DTO/Rank_DTO.cs
+++ b/API_Game_server/Model/DTO/Rank_DTO.cs
@@ -10,6 +10,7 @@ namespace API_Game_Server.Model.DTO
     public class RanksLoadReq
     {
         public int Page { get; set; }
+        public int PlayerNum { get; set; }
     }
     public class RanksLoadRes : ErrorCodeDTO
     {

--- a/API_Game_server/Repository/Interface/IRedisDB.cs
+++ b/API_Game_server/Repository/Interface/IRedisDB.cs
@@ -7,7 +7,7 @@ public interface IRedisDB
 {
     public Task<bool> SetZset(string key, string member, double score);
     public Task<long?> GetZsetRank(string key, string member);
-    public Task<RedisValue[]> GetZsetRanks(string key, int page);
+    public Task<SortedSetEntry[]> GetZsetRanks(string key, int page, int playerNum);
     public Task<long> GetZsetSize(string key);
     public Task<long> ClearZset(string key);
     public Task<string> GetSessionIdAsync(Int64 uidKey);

--- a/API_Game_server/Repository/RedisDB _ZSet.cs
+++ b/API_Game_server/Repository/RedisDB _ZSet.cs
@@ -24,11 +24,18 @@ namespace API_Game_Server.Repository
             long? result = await _db.SortedSetRankAsync((RedisKey)key, (RedisValue)member, Order.Descending);
             return result;
         }
-        public async Task<RedisValue[]> GetZsetRanks(string key, int page)
+        public async Task<SortedSetEntry[]> GetZsetRanks(string key, int page, int playerNum)
+        {
+            long startNum = (page - 1) * playerNum;
+            long endNum = (page) * playerNum - 1;
+            SortedSetEntry[] result =  await _db.SortedSetRangeByRankWithScoresAsync(key, startNum, endNum, Order.Descending);
+            return result;
+        }
+        public async Task<RedisValue[]> GetZsetRanksScore(string key, int page)
         {
             long startNum = (page - 1) * 15;
             long endNum = (page) * 15 - 1;
-            RedisValue[] result = await _db.SortedSetRangeByRankAsync(key, startNum, endNum, Order.Descending);
+            RedisValue[] result = await _db.SortedSetRangeByRankAsync(key, startNum, endNum, order:Order.Descending);
             return result;
         }
         public async Task<long> GetZsetSize(string key)

--- a/API_Game_server/Services/RankService.cs
+++ b/API_Game_server/Services/RankService.cs
@@ -29,12 +29,17 @@ namespace API_Game_Server.Services
         }
         public async Task<EErrorCode> LoadRanks(RanksLoadReq req, RanksLoadRes res)
         {
-            RedisValue[] result = await redisDB.GetZsetRanks("rank", req.Page);
+            SortedSetEntry[] result = await redisDB.GetZsetRanks("rank", req.Page, req.PlayerNum);
             if (result.Length == 0)
             {
                 return EErrorCode.RankersNotExist;
             }
-            res.Ranks = Array.ConvertAll(result, x => (string)x);
+            string[] ranks = new string[result.Length];
+            for (int i = 0; i < result.Length; i++)
+            {
+                ranks[i] = $"{result[i].Element}:{result[i].Score}";
+            }
+            res.Ranks = ranks;
             return EErrorCode.None;
         }
         public async Task<EErrorCode> GetSizeOfRanks(RankSizeRes res)

--- a/API_Game_server/Services/RankService.cs
+++ b/API_Game_server/Services/RankService.cs
@@ -1,3 +1,4 @@
+using API_Game_Server.Model.DAO;
 using API_Game_Server.Model.DTO;
 using API_Game_Server.Repository;
 using API_Game_Server.Repository.Interface;
@@ -18,13 +19,14 @@ namespace API_Game_Server.Services
         public async Task<EErrorCode> GetRank(string sessionId, RankGetRes res)
         {
             long userUid = await validationService.GetUid(sessionId);
+            UserInfo userInfo = await redisDB.GetString<UserInfo>($"user_info:session_id:{sessionId}");
             var result = await redisDB.GetZsetRank("rank", userUid.ToString());
             if (result == null)
             {
                 // 유저가 랭킹에 존재하지 않는다. -> 아직 게임을 진행하지 않은 유저
                 return EErrorCode.IsNewbie;
             }
-            res.Rank = (long)result + 1;
+            res.Rank = $"{result + 1}:{userInfo.MaxScore}";
             return EErrorCode.None;
         }
         public async Task<EErrorCode> LoadRanks(RanksLoadReq req, RanksLoadRes res)


### PR DESCRIPTION
기존의 api는 랭크에 따른 닉네임만 반환했다.    
닉네임과 점수를 같이 반환하도록 수정했다.   
