### PR TITLE
미들웨어에서 세션 ID를 검증하는 코드 추가

### DIFF
--- a/API_Game_server/Middleware/VerifyUserAuth.cs
+++ b/API_Game_server/Middleware/VerifyUserAuth.cs
@@ -52,20 +52,13 @@ public class VerifyUserAuth
             return;
         }
         
-        // // redis에서 uid에 해당하는 sessionId를 불러옴
-        // string redisSessionId = await redisDb.GetSessionIdAsync(uid);
-        // if(redisSessionId == null)
-        // {
-        //     await ErrorResponse(context, StatusCodes.Status401Unauthorized, EErrorCode.SessionIdNotFound);
-        //     return;
-        // }
-
-        //// sessionId가 일치하는지 검사
-        //if(!IsValidSessionId(context, sessionId, redisSessionId))
-        //{
-        //    await ErrorResponse(context, StatusCodes.Status401Unauthorized, EErrorCode.AuthFailWrongSessionId);
-        //    return;
-        //}
+        // redis에 sessionId가 존재하는지 확인
+        bool existSessionId = await redisDb.ExistSessionIdAsync(sessionId);
+        if (!existSessionId)
+        {
+            await ErrorResponse(context, StatusCodes.Status401Unauthorized, EErrorCode.SessionIdNotFound);
+            return;
+        }
 
         AuthInfo authInfo = new();
         authInfo.Uid = uid;

--- a/API_Game_server/Repository/Interface/IRedisDB.cs
+++ b/API_Game_server/Repository/Interface/IRedisDB.cs
@@ -10,7 +10,7 @@ public interface IRedisDB
     public Task<RedisValue[]> GetZsetRanks(string key, int page);
     public Task<long> GetZsetSize(string key);
     public Task<long> ClearZset(string key);
-    public Task<string> GetSessionIdAsync(Int64 uidKey);
+    public Task<bool> ExistSessionIdAsync(string sessionId);
     public Task SetHash<T>(string key, T obj) where T : class;
     public Task<string[]> GetHash(string key, string[] Items);
     public Task<bool> ClearHash(string key);

--- a/API_Game_server/Repository/RedisDB_Auth.cs
+++ b/API_Game_server/Repository/RedisDB_Auth.cs
@@ -6,14 +6,19 @@ namespace API_Game_Server.Repository;
 
 public partial class RedisDB : IRedisDB
 {
-    private const string authUid = "user_info:uid:";
+    private const string authUid = "user_info:session_id:";
 
-    public async Task<string> GetSessionIdAsync(Int64 uidKey)
+    public async Task<bool> ExistSessionIdAsync(string sessionId)
     {
-        string uid = authUid + uidKey.ToString();
-        string[] uidValues = { "SessionId" };
-        string[] sessionId = await GetHash(uid, uidValues);
+        string key = authUid + sessionId;
 
-        return sessionId[0];
+        string redisSessionId = await GetString(key);
+
+        if (redisSessionId == "")
+        {
+            return false;
+        }
+
+        return true;
     }
 }


### PR DESCRIPTION
Redis에 요청한 세션ID가 존재하지 않으면 EErrorCode.SessionIdNotFound를 반환한다. (인증 실패를 의미,)