### PR TITLE
Fix Rank API

### DIFF
--- a/API_Game_server/Services/RankService.cs
+++ b/API_Game_server/Services/RankService.cs
@@ -20,7 +20,7 @@ namespace API_Game_Server.Services
         {
             long userUid = await validationService.GetUid(sessionId);
             UserInfo userInfo = await redisDB.GetString<UserInfo>($"user_info:session_id:{sessionId}");
-            var result = await redisDB.GetZsetRank("rank", userUid.ToString());
+            var result = await redisDB.GetZsetRank("rank", userInfo.UserName);
             if (result == null)
             {
                 // 유저가 랭킹에 존재하지 않는다. -> 아직 게임을 진행하지 않은 유저


### PR DESCRIPTION
내 랭킹이 업데이트 되지 않는 문제 해결,   
찾고자 하는 멤버명이 UserName이었는데, Uid로 찾고있어서 해당 문제가 발생   
코드를 수정하여 정상적으로 작동하는 것 확인   
